### PR TITLE
paramsをsnakecaseに変換する処理追加

### DIFF
--- a/app/controllers/api/books_controller.rb
+++ b/app/controllers/api/books_controller.rb
@@ -21,7 +21,7 @@ module Api
     private
 
     def book_params
-      params.require(:book).permit(:title, :author, :cover_image_url)
+      params.permit(:title, :author, :cover_image_url)
     end
 
     def create_user_book(book, email)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  before_action :camel2snake_params
+
+  private
+
+  def camel2snake_params
+    params.deep_transform_keys!(&:underscore)
+  end
 end

--- a/spec/requests/api/books_spec.rb
+++ b/spec/requests/api/books_spec.rb
@@ -28,16 +28,16 @@ RSpec.describe 'Api::Books', type: :request do
   describe 'Api::BooksController#create' do
     context 'params is valid' do
       it 'return a successful response' do
-        book_params = { book: { title: 'テスト本のタイトル', author: 'テスト本の著者', cover_image_url: 'http://localhost:3000/testcoverimageurl' }, email: @user.email, heading_number: 5 }
-        post api_books_path, params: book_params
+        params = { title: 'テスト本のタイトル', author: 'テスト本の著者', coverImageUrl: 'http://localhost:3000/testcoverimageurl', email: @user.email, headingNumber: 5 }
+        post(api_books_path, params:)
         expect(response).to have_http_status(:ok)
       end
     end
 
     context 'params is not valid' do
       it 'return a bad response' do
-        book_params = { book: { title: 'テスト本のタイトル', author: 'テスト本の著者' }, email: @user.email }
-        post api_books_path, params: book_params
+        params = { title: 'テスト本のタイトル', author: 'テスト本の著者', email: @user.email }
+        post(api_books_path, params:)
         expect(response).to have_http_status(:internal_server_error)
       end
     end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/52

## description
application_controllerにparamsをスネークケースに変換する処理追加。
それに伴い、ストロングパラメータのモデル指定を削除。