### PR TITLE
Userモデルにhandle_nameカラムを追加

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -2,6 +2,12 @@
 
 module Api
   class AuthController < ApplicationController
+    def add_session_user_data
+      user = User.find_by(email: params[:email])
+
+      render json: { id: user.id.to_s, handle_name: user.handle_name }
+    end
+
     def login
       user = User.find_by(uid: params[:uid])
 

--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -7,15 +7,5 @@ module Api
 
       render json: { id: user.id.to_s, handle_name: user.handle_name }
     end
-
-    def login
-      user = User.find_by(uid: params[:uid])
-
-      if user
-        head :ok
-      else
-        head :no_content
-      end
-    end
   end
 end

--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Api
+  class AuthController < ApplicationController
+    def login
+      user = User.find_by(uid: params[:uid])
+
+      if user
+        head :ok
+      else
+        head :no_content
+      end
+    end
+  end
+end

--- a/app/controllers/api/headings_controller.rb
+++ b/app/controllers/api/headings_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class HeadingsController < ApplicationController
+    before_action :authenticate, only: [:update]
+
     def update
       heading = Heading.find(params[:id])
       if heading.update(title: params[:title])

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -2,7 +2,7 @@
 
 module Api
   class MemosController < ApplicationController
-    before_action :authenticate, only: [:index]
+    before_action :authenticate, only: %i[index update]
 
     def index
       user_book = UserBook.preload(headings: :memo).find_by(user: current_user, book_id: params[:book_id])

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,19 +2,32 @@
 
 module Api
   class UsersController < ApplicationController
-    before_action :authenticate, only: %i[show destroy]
+    before_action :authenticate, only: %i[update destroy]
 
     def show
-      user_info = current_user.info
+      user_info = User.find_by(handle_name: params[:handle_name]).info
       render json: user_info
     end
 
     def create
-      user = User.find_or_create_by(user_params)
+      user = User.find_or_initialize_by(user_params)
+      user.handle_name = "User_#{SecureRandom.uuid}" if user.new_record?
+
       if user.persisted?
         head :ok
+      elsif user.save
+        head :created
       else
         render json: { error: 'ログインに失敗しました' }, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      Rails.logger.debug current_user
+      if current_user.update(handle_name: params[:handle_name])
+        head :ok
+      else
+        render json: { error: current_user.errors.full_messages.join(', ') }, status: :unprocessable_entity
       end
     end
 
@@ -29,7 +42,7 @@ module Api
     private
 
     def user_params
-      params.permit(:name, :email, :avatar_url, :uid)
+      params.permit(:id, :name, :email, :avatar_url, :uid, :handle_name)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
   private
 
   def authenticate
-    @current_user = User.find_by(uid: params[:uid])
+    @current_user = User.find(params[:id])
   end
 
   def camel2snake_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
   private
 
   def authenticate
-    @current_user = User.find(params[:id])
+    @current_user = User.find(params[:user_id])
   end
 
   def camel2snake_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
     validates :email, uniqueness: true
     validates :avatar_url
     validates :uid
+    validates :handle_name, uniqueness: true
   end
 
   has_many :user_books, dependent: :destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  post '/api/auth/callback/google', to: 'api/users#create'
+  post '/api/auth/callback/google', to: 'api/auth#login'
   namespace :api do
     resources :books, only: %i[index create] do
       resources :memos, only: %i[index update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  post '/api/auth/callback/google', to: 'api/auth#login'
+  post '/api/auth/callback/google', to: 'api/users#create'
+  get 'api/auth/add_session_user_data', to: 'api/auth#add_session_user_data'
   namespace :api do
     resources :books, only: %i[index create] do
       resources :memos, only: %i[index update]
     end
     resources :reading_logs, only: %i[index create]
     resources :headings, only: %i[update]
-    resources :users, only: %i[show destroy]
+    resources :users, only: %i[show update destroy]
     resources :user_books, only: %i[destroy] do
       collection do
         post :move_position

--- a/db/migrate/20240831005318_add_handle_name_to_users.rb
+++ b/db/migrate/20240831005318_add_handle_name_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddHandleNameToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :handle_name, :string
+    add_index :users, :handle_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_074156) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_31_005318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,7 +66,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_074156) do
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "handle_name"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["handle_name"], name: "index_users_on_handle_name", unique: true
   end
 
   add_foreign_key "headings", "user_books"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     email { Faker::Internet.email }
     avatar_url { 'https://hogehoge-image' }
     uid { Faker::IdNumber.south_african_id_number }
+    handle_name { Faker::Name.name }
   end
 end

--- a/spec/requests/api/auth_spec.rb
+++ b/spec/requests/api/auth_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::Auths', type: :request do
+  before do
+    @user = FactoryBot.create(:user)
+  end
+
+  describe 'Api::AuthController#add_session_user_data' do
+    context 'params is valid' do
+      it 'return a successful response' do
+        user_params = { email: @user.email }
+        get api_auth_add_session_user_data_path, params: user_params
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq({ id: @user.id.to_s, handle_name: @user.handle_name }.to_json)
+      end
+    end
+  end
+end

--- a/spec/requests/api/books_spec.rb
+++ b/spec/requests/api/books_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Api::Books', type: :request do
   describe 'Api::BooksController#index' do
     context 'params is valid' do
       it 'return a successful response' do
-        params = { uid: @user.uid }
+        params = { user_id: @user.id }
         get(api_books_path, params:)
         expect(response).to have_http_status(:ok)
       end
@@ -28,7 +28,7 @@ RSpec.describe 'Api::Books', type: :request do
   describe 'Api::BooksController#create' do
     context 'params is valid' do
       it 'return a successful response' do
-        params = { title: 'テスト本のタイトル', author: 'テスト本の著者', coverImageUrl: 'http://localhost:3000/testcoverimageurl', uid: @user.uid, headingNumber: 5 }
+        params = { title: 'テスト本のタイトル', author: 'テスト本の著者', coverImageUrl: 'http://localhost:3000/testcoverimageurl', user_id: @user.id, headingNumber: 5 }
         post(api_books_path, params:)
         expect(response).to have_http_status(:ok)
       end
@@ -36,7 +36,7 @@ RSpec.describe 'Api::Books', type: :request do
 
     context 'params is not valid' do
       it 'return a bad response' do
-        params = { title: 'テスト本のタイトル', author: 'テスト本の著者', uid: @user.uid }
+        params = { title: 'テスト本のタイトル', author: 'テスト本の著者', user_id: @user.id }
         post(api_books_path, params:)
         expect(response).to have_http_status(:unprocessable_entity)
       end

--- a/spec/requests/api/headings_spec.rb
+++ b/spec/requests/api/headings_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Api::Headings', type: :request do
   describe 'Api::HeadingsController#update' do
     context 'params is valid' do
       it 'return a successful response' do
-        params = { id: @heading.id, title: '更新後のタイトル' }
+        params = { user_id: @heading.user_book.user.id, id: @heading.id, title: '更新後のタイトル' }
         patch(api_heading_path(@heading.id), params:)
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/api/memos_spec.rb
+++ b/spec/requests/api/memos_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Api::Memos', type: :request do
   describe 'Api::MemosController#index' do
     context 'params is valid' do
       it 'return a successful response' do
-        params = { uid: @user.uid }
+        params = { user_id: @user.id }
         get(api_reading_logs_path, params:)
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/api/reading_logs_spec.rb
+++ b/spec/requests/api/reading_logs_spec.rb
@@ -5,12 +5,25 @@ require 'rails_helper'
 RSpec.describe 'Api::ReadingLogs', type: :request do
   before do
     @memo = FactoryBot.create(:memo)
+    @user = @memo.heading.user_book.user
+    @reading_log = FactoryBot.create(:reading_log, memo: @memo)
+  end
+
+  describe 'Api::ReadingLogsController#index' do
+    context 'params is valid' do
+      it 'return logs with date and count set' do
+        params = { user_id: @user.id }
+        get(api_reading_logs_path, params:)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq([{ date: @reading_log.read_date.to_s, count: 1 }].to_json)
+      end
+    end
   end
 
   describe 'Api::ReadingLogsController#create' do
     context 'params is valid' do
       it 'return a successful response' do
-        params = { memo_id: @memo.id }
+        params = { user_id: @user.id, memo_id: @memo.id }
         post(api_reading_logs_path, params:)
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/api/user_books_spec.rb
+++ b/spec/requests/api/user_books_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Api::UserBooks', type: :request do
         expect(@user_book.position).to eq(1)
         second_user_book = FactoryBot.create(:user_book, user: @user_book.user)
         expect(second_user_book.position).to eq(2)
-        params = { book_id: @user_book.book.id, destination_book_id: second_user_book.book.id, uid: @user_book.user.uid }
+        params = { book_id: @user_book.book.id, destination_book_id: second_user_book.book.id, user_id: @user_book.user.id }
         post(move_position_api_user_books_path, params:)
         @user_book.reload
         expect(@user_book.position).to eq(2)
@@ -25,7 +25,7 @@ RSpec.describe 'Api::UserBooks', type: :request do
   describe 'Api::UserBooksController#destroy' do
     context 'params is valid' do
       it 'return a nocontent response' do
-        params = { book_id: @user_book.book.id, uid: @user_book.user.uid }
+        params = { book_id: @user_book.book.id, user_id: @user_book.user.id }
         delete(api_user_book_path(@user_book.user.id), params:)
         expect(response).to have_http_status(:no_content)
       end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -13,9 +13,17 @@ RSpec.describe 'Api::Users', type: :request do
   end
 
   describe 'Api::UsersController#create' do
-    context 'params is valid' do
-      it 'return a successful response' do
+    context 'registering new user' do
+      it 'return a created response' do
         user_params = { name: 'hoge', email: 'hogehoge@example.com', avatar_url: 'https://hogehoge', uid: '00000000001' }
+        post api_auth_callback_google_path, params: user_params
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'when a user logs in' do
+      it 'return a ok response' do
+        user_params = { name: @user.name, email: @user.email, avatar_url: @user.avatar_url, uid: @user.uid }
         post api_auth_callback_google_path, params: user_params
         expect(response).to have_http_status(:ok)
       end
@@ -32,7 +40,7 @@ RSpec.describe 'Api::Users', type: :request do
     describe 'Api::UsersController#show' do
       context 'params is valid' do
         it 'return a user_info' do
-          params = { uid: @user.uid }
+          params = { handle_name: @user.handle_name }
           get("/api/users/#{@user.uid}", params:)
           expect(response).to have_http_status(:ok)
         end
@@ -42,7 +50,7 @@ RSpec.describe 'Api::Users', type: :request do
     describe 'Api::UsersController#destroy' do
       context 'params is valid' do
         it 'return a nocontent response' do
-          params = { uid: @user.uid }
+          params = { user_id: @user.id }
           delete("/api/users/#{@user.uid}", params:)
           expect(response).to have_http_status(:no_content)
         end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/93
## description
Googleの名前は一意ではないため、別途handle_nameを用意して、最初のログイン時はhandle_name設定のページを表示するように実装。