### PR TITLE
libディレクトリのオートロード設定を追加

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ Bundler.require(*Rails.groups)
 module TsundokuBackend
   class Application < Rails::Application
     config.load_defaults 7.1
+    config.autoload_paths += %W[#{config.root}/lib/monkey_patches]
 
     config.autoload_lib(ignore: %w[assets tasks])
 


### PR DESCRIPTION
本番環境で、Heroku側でswap_position_withを読み込めないというエラーが出たため。