### PR TITLE
読書ログのJSONを年度ごとに返すように実装

### DIFF
--- a/app/resources/daily_reading_log_resource.rb
+++ b/app/resources/daily_reading_log_resource.rb
@@ -2,8 +2,14 @@
 
 class DailyReadingLogResource < BaseResource
   attribute :logs do |user|
-    user.reading_logs.group(:read_date).count.map do |date, count|
-      { date: date.to_s, count: }
+    first_year = user.reading_logs.first.read_date.year
+    years = (first_year..Time.current.year).to_a
+    years.index_with do |year|
+      user.reading_logs
+          .where(read_date: Time.zone.local(year).all_year)
+          .group(:read_date)
+          .count
+          .map { |date, count| { date: date.to_s, count: } }
     end
   end
 end

--- a/spec/requests/api/reading_logs_spec.rb
+++ b/spec/requests/api/reading_logs_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'API::ReadingLogs', type: :request do
       it 'returns logs with date and count set' do
         get(api_reading_logs_path)
         expect(response).to have_http_status(:ok)
-        expect(response.body).to eq({ logs: [{ date: @reading_log.read_date.to_s, count: 1 }] }.to_json)
+        expect(response.body).to eq({ logs: { "#{@reading_log.read_date.year}": [{ date: @reading_log.read_date.to_s, count: 1 }] } }.to_json)
       end
     end
   end

--- a/spec/resources/daily_reading_log_resource_spec.rb
+++ b/spec/resources/daily_reading_log_resource_spec.rb
@@ -14,14 +14,20 @@ RSpec.describe DailyReadingLogResource, type: :resource do
 
   it 'returns the daily reading logs' do
     reading_log_json = DailyReadingLogResource.new(@user).serialize
+    first_year = @reading_logs.min_by(&:read_date).read_date.year
     expected_reading_log_json = {
-      logs: @reading_logs.sort_by(&:read_date).map do |log|
-        {
-          date: log.read_date.to_s,
-          count: 1
-        }
+      logs: (first_year..Time.current.year).to_a.to_h do |year|
+        [
+          year.to_s,
+          @reading_logs
+            .select { |log| log.read_date.year == year }
+            .group_by(&:read_date)
+            .sort
+            .map { |date, logs| { date: date.to_s, count: logs.size } }
+        ]
       end
     }.to_json
+
     expect(reading_log_json).to eq(expected_reading_log_json)
   end
 end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/144

## description
以前はすべての reading_logs をそのまま返していたが、ユーザーのログが存在する年度を判定し、年度ごとにグルーピングして返すように変更。