### PR TITLE
読書ログが全くない人がログインできない問題を修正

### DIFF
--- a/app/resources/daily_reading_log_resource.rb
+++ b/app/resources/daily_reading_log_resource.rb
@@ -2,14 +2,20 @@
 
 class DailyReadingLogResource < BaseResource
   attribute :logs do |user|
-    first_year = user.reading_logs.first.read_date.year
-    years = (first_year..Time.current.year).to_a
-    years.index_with do |year|
-      user.reading_logs
+    reading_logs = user.reading_logs
+    first_reading_log = reading_logs.first
+
+    if first_reading_log
+      years = (first_reading_log.read_date.year..Time.current.year).to_a
+      years.index_with do |year|
+        reading_logs
           .where(read_date: Time.zone.local(year).all_year)
           .group(:read_date)
           .count
           .map { |date, count| { date: date.to_s, count: } }
+      end
+    else
+      {}
     end
   end
 end

--- a/spec/factories/reading_logs.rb
+++ b/spec/factories/reading_logs.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :reading_log do
-    read_date { Faker::Date.on_day_of_week_between(day: :monday, from: 1.year.ago, to: '2024-07-21') }
+    read_date { Faker::Date.on_day_of_week_between(day: :monday, from: 1.year.ago, to: Time.zone.today) }
     memo
   end
 end

--- a/spec/requests/api/reading_logs_spec.rb
+++ b/spec/requests/api/reading_logs_spec.rb
@@ -16,7 +16,12 @@ RSpec.describe 'API::ReadingLogs', type: :request do
       it 'returns logs with date and count set' do
         get(api_reading_logs_path)
         expect(response).to have_http_status(:ok)
-        expect(response.body).to eq({ logs: { "#{@reading_log.read_date.year}": [{ date: @reading_log.read_date.to_s, count: 1 }] } }.to_json)
+        reading_log_year = @reading_log.read_date.year
+        current_year = Time.zone.today.year
+        expected_response_json = { logs: { "#{reading_log_year}": [{ date: @reading_log.read_date.to_s, count: 1 }] } }
+        expected_response_json[:logs][current_year.to_s] = [] if reading_log_year < current_year
+
+        expect(response.body).to eq(expected_response_json.to_json)
       end
     end
   end

--- a/spec/resources/daily_reading_log_resource_spec.rb
+++ b/spec/resources/daily_reading_log_resource_spec.rb
@@ -30,4 +30,12 @@ RSpec.describe DailyReadingLogResource, type: :resource do
 
     expect(reading_log_json).to eq(expected_reading_log_json)
   end
+
+  it 'returns the empty log when user does not have reading logs' do
+    new_user = FactoryBot.create(:user)
+    reading_log_json = DailyReadingLogResource.new(new_user).serialize
+    expected_reading_log_json = { logs: {} }.to_json
+
+    expect(reading_log_json).to eq(expected_reading_log_json)
+  end
 end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/147

## description
エラーの一部抜粋 : 
```
2025-02-07T06:09:09.275423+00:00 app[web.1]: [a0a3fafc-083c-44b4-9e19-b3929252e670] NoMethodError (undefined method `read_date' for nil):
```

以下のPRによる影響 : 

- https://github.com/reckyy/tsundoku-backend/pull/37

読書ログを年ごとに表示するために、ユーザーの最初の読書ログから現在までのログを整理してJSONを返していた。
しかし、読書ログが存在しないユーザーを考慮していなかった ため、nil に対して read_date を呼び出すことでエラーが発生していた。
ログの有無で、処理を分岐させることで対応。