### PR TITLE
DailyReadingLogResourceのリファクタリング

### DIFF
--- a/spec/resources/daily_reading_log_resource_spec.rb
+++ b/spec/resources/daily_reading_log_resource_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe DailyReadingLogResource, type: :resource do
     expected_reading_log_json = {
       logs: {
         last_year_reading_log.read_date.year.to_s => [
-          date: last_year_reading_log.read_date,
+          date: last_year_reading_log.read_date.to_s,
           count: 1
         ],
         reading_log.read_date.year.to_s => [
-          date: reading_log.read_date,
+          date: reading_log.read_date.to_s,
           count: 1
         ]
       }

--- a/spec/resources/user_info_resource_spec.rb
+++ b/spec/resources/user_info_resource_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe UserInfoResource, type: :resource do
       logs: {
         reading_log.read_date.year.to_s => [
           {
-            date: reading_log.read_date,
+            date: reading_log.read_date.to_s,
             count: 1
           }
         ]


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/156

## description
以下の問題を解消。

- 「最初のログが存在するか？」という条件ではなく、そもそも`reading_logs`が空かどうかを確認すればいい。無駄なステップ。
- 処理手順がわかりにくいため、シンプルに修正。
- yearごとにクエリを発行しており、N+1問題が発生していた。これを1回の集約クエリ + Ruby側でのグルーピングに置き換え解消。