### PR TITLE
各コントローラーにリソースの所有者チェックを追加

### DIFF
--- a/app/controllers/api/headings_controller.rb
+++ b/app/controllers/api/headings_controller.rb
@@ -3,7 +3,8 @@
 module API
   class HeadingsController < ApplicationController
     def create
-      heading = Heading.new(user_book_id: params[:user_book_id], number: params[:number].to_i, title: '', memo_attributes: {})
+      user_book = current_user.user_books.find(params[:user_book_id])
+      heading = Heading.new(user_book:, number: params[:number].to_i, title: '', memo_attributes: {})
       if heading.save
         render json: HeadingResource.new(heading).serializable_hash
       else
@@ -12,7 +13,7 @@ module API
     end
 
     def update
-      heading = Heading.find(params[:id])
+      heading = current_user.headings.find(params[:id])
       if heading.update(title: params[:title])
         head :ok
       else

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -8,7 +8,7 @@ module API
     end
 
     def update
-      memo = Memo.find(params[:id])
+      memo = current_user.memos.find(params[:id])
       if memo.update(body: params[:body])
         head :ok
       else

--- a/app/controllers/api/reading_logs_controller.rb
+++ b/app/controllers/api/reading_logs_controller.rb
@@ -7,7 +7,8 @@ module API
     end
 
     def create
-      reading_log = ReadingLog.find_or_create_by(memo_id: params[:memo_id], read_date: Time.zone.today)
+      memo = current_user.memos.find(params[:memo_id])
+      reading_log = ReadingLog.find_or_create_by(memo:, read_date: Time.zone.today)
       if reading_log.persisted?
         head :ok
       else

--- a/app/controllers/api/user_books_controller.rb
+++ b/app/controllers/api/user_books_controller.rb
@@ -25,7 +25,7 @@ module API
     end
 
     def position
-      destination_user_book = UserBook.find(params[:destination_book_id])
+      destination_user_book = current_user.user_books.find(params[:destination_book_id])
       if @user_book.swap_positions_with(destination_user_book)
         head :ok
       else
@@ -56,7 +56,7 @@ module API
     end
 
     def set_user_book
-      @user_book = UserBook.find(params[:id])
+      @user_book = current_user.user_books.find(params[:id])
     end
   end
 end

--- a/spec/requests/api/headings_spec.rb
+++ b/spec/requests/api/headings_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'API::Headings', type: :request do
   let(:current_user) { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user) }
 
   before do
     book = FactoryBot.create(:book)
@@ -22,10 +23,20 @@ RSpec.describe 'API::Headings', type: :request do
     end
 
     context 'params is invalid' do
-      it 'returns a bad response' do
+      it 'returns not found' do
         params = { user_book_id: -1, number: 2 }
         post(api_headings_path, params:)
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the user_book belongs to another user' do
+      it 'returns not found' do
+        other_user_book = UserBook.create(user: other_user, book: FactoryBot.create(:book))
+        params = { user_book_id: other_user_book.id, number: 2 }
+
+        expect { post(api_headings_path, params:) }.not_to(change { Heading.count })
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -47,6 +58,19 @@ RSpec.describe 'API::Headings', type: :request do
         params = { id: @heading.id, title: '更新後のタイトル' }
         patch(api_heading_path(@heading.id), params:)
         expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the heading belongs to another user' do
+      it 'returns not found' do
+        other_user_book = UserBook.create(user: other_user, book: FactoryBot.create(:book))
+        other_heading = FactoryBot.create(:heading, user_book: other_user_book)
+        params = { id: other_heading.id, title: '更新後のタイトル' }
+
+        patch(api_heading_path(other_heading.id), params:)
+
+        expect(response).to have_http_status(:not_found)
+        expect(other_heading.reload.title).not_to eq('更新後のタイトル')
       end
     end
   end

--- a/spec/requests/api/memos_spec.rb
+++ b/spec/requests/api/memos_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'API::Memos', type: :request do
   let(:current_user) { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user) }
 
   before do
     @book = FactoryBot.create(:book)
@@ -40,6 +41,20 @@ RSpec.describe 'API::Memos', type: :request do
         params = { id: @memo.id, body: '更新後のメモ' }
         patch(api_memo_path(@memo.id), params:)
         expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the memo belongs to another user' do
+      it 'returns not found' do
+        other_user_book = UserBook.create(user: other_user, book: FactoryBot.create(:book))
+        other_heading = FactoryBot.create(:heading, user_book: other_user_book)
+        other_memo = FactoryBot.create(:memo, heading: other_heading)
+        params = { id: other_memo.id, body: '更新後のメモ' }
+
+        patch(api_memo_path(other_memo.id), params:)
+
+        expect(response).to have_http_status(:not_found)
+        expect(other_memo.reload.body).not_to eq('更新後のメモ')
       end
     end
   end

--- a/spec/requests/api/reading_logs_spec.rb
+++ b/spec/requests/api/reading_logs_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'API::ReadingLogs', type: :request do
   let(:current_user) { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user) }
 
   before do
     book = FactoryBot.create(:book)
@@ -35,10 +36,22 @@ RSpec.describe 'API::ReadingLogs', type: :request do
     end
 
     context 'params is invalid' do
-      it 'returns a bad response' do
+      it 'returns not found' do
         params = { memo_id: -1 }
         post(api_reading_logs_path, params:)
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the memo belongs to another user' do
+      it 'returns not found' do
+        other_user_book = UserBook.create(user: other_user, book: FactoryBot.create(:book))
+        other_heading = FactoryBot.create(:heading, user_book: other_user_book)
+        other_memo = FactoryBot.create(:memo, heading: other_heading)
+        params = { memo_id: other_memo.id }
+
+        expect { post(api_reading_logs_path, params:) }.not_to(change { ReadingLog.count })
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/api/user_books_spec.rb
+++ b/spec/requests/api/user_books_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'API::UserBooks', type: :request do
   let(:current_user) { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user) }
   let(:second_book) { FactoryBot.create(:book) }
   let(:second_user_book) { UserBook.create(user: current_user, book: second_book) }
 
@@ -63,6 +64,17 @@ RSpec.describe 'API::UserBooks', type: :request do
         expect(response).to have_http_status(422)
       end
     end
+
+    context 'when the destination user_book belongs to another user' do
+      it 'returns not found' do
+        other_user_book = UserBook.create(user: other_user, book: FactoryBot.create(:book))
+        params = { user_book_id: @user_book.id, destination_book_id: other_user_book.id }
+
+        patch(position_api_user_book_path(@user_book.id), params:)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe 'API::UserBooksController#update' do
@@ -84,6 +96,18 @@ RSpec.describe 'API::UserBooks', type: :request do
         expect(response).to have_http_status(422)
       end
     end
+
+    context 'when the user_book belongs to another user' do
+      it 'returns not found' do
+        other_user_book = UserBook.create(user: other_user, book: FactoryBot.create(:book))
+        params = { user_book_id: other_user_book.id, status: 'reading' }
+
+        patch(api_user_book_path(other_user_book.id), params:)
+
+        expect(response).to have_http_status(:not_found)
+        expect(other_user_book.reload.status).not_to eq('reading')
+      end
+    end
   end
 
   describe 'API::UserBooksController#destroy' do
@@ -101,6 +125,16 @@ RSpec.describe 'API::UserBooks', type: :request do
         params = { user_book_id: @user_book.id }
         expect { delete(api_user_book_path(@user_book.id), params:) }.not_to(change { UserBook.count })
         expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the user_book belongs to another user' do
+      it 'returns not found' do
+        other_user_book = UserBook.create(user: other_user, book: FactoryBot.create(:book))
+        params = { user_book_id: other_user_book.id }
+
+        expect { delete(api_user_book_path(other_user_book.id), params:) }.not_to(change { UserBook.count })
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
## Issue

- https://github.com/reckyy/tsundoku/issues/173

## description

- 各コントローラで対象リソースを`current_user`経由で取得するように変更
- `Heading`作成時の`user_book_id`、`ReadingLog`作成時の`memo_id`に所有者チェックを追加
- 他ユーザーのリソースアクセスで`404`を返すrequest specを追加し、関連する既存specの期待値も更新

