### PR TITLE
JWTに有効期限(exp claim)を追加

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,6 +2,8 @@
 
 module API
   class UsersController < ApplicationController
+    JWT_EXPIRATION = 30.days
+
     before_action :verify_google_id_token, only: %i[create]
     skip_before_action :authenticate, only: %i[show create]
 
@@ -14,8 +16,14 @@ module API
       user = User.find_or_create_by(user_params)
 
       if user.persisted?
-        encoded_token = encode_jwt({ id: user.id })
-        render json: { id: user.id, access_token: encoded_token }
+        access_token_expires_at = JWT_EXPIRATION.from_now
+        encoded_token = encode_jwt({ id: user.id, exp: access_token_expires_at.to_i })
+
+        render json: {
+          id: user.id,
+          access_token: encoded_token,
+          access_token_expires_at: access_token_expires_at.iso8601
+        }
       else
         render json: { error: 'ログインに失敗しました' }, status: :unprocessable_entity
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::API
     secret_key = ENV.fetch('SECRET_KEY_BASE')
     decoded_token = JWT.decode(token, secret_key, true, algorithm: 'HS256')
     @current_user = User.find(decoded_token[0]['id'])
-  rescue JWT::DecodeError, ActiveRecord::RecordNotFound
+  rescue JWT::ExpiredSignature, JWT::DecodeError, ActiveRecord::RecordNotFound
     render_unauthorized
   end
 

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -31,8 +31,17 @@ RSpec.describe 'Authentication', type: :request do
       expect(response.parsed_body).to eq('errors' => ['Not Authenticated'])
     end
 
+    it 'returns unauthorized when the token is expired' do
+      token = JWT.encode({ id: user.id, exp: 1.minute.ago.to_i }, secret_key, 'HS256')
+
+      get api_reading_logs_path, headers: { Authorization: "Bearer #{token}" }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body).to eq('errors' => ['Not Authenticated'])
+    end
+
     it 'returns ok when the token is valid' do
-      token = JWT.encode({ id: user.id }, secret_key, 'HS256')
+      token = JWT.encode({ id: user.id, exp: 30.days.from_now.to_i }, secret_key, 'HS256')
 
       get api_reading_logs_path, headers: { Authorization: "Bearer #{token}" }
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe 'API::Users', type: :request do
         user_params = { name: 'hoge', email: Faker::Internet.email, avatar_url: Faker::Internet.url }
         expect { post api_auth_callback_google_path, params: user_params }.to change { User.count }.by(1)
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['access_token']).to be_present
+        expect(response.parsed_body['access_token_expires_at']).to be_present
       end
     end
 
@@ -28,6 +30,8 @@ RSpec.describe 'API::Users', type: :request do
         user_params = { name: current_user.name, email: current_user.email, avatar_url: current_user.avatar_url }
         post api_auth_callback_google_path, params: user_params
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['access_token']).to be_present
+        expect(response.parsed_body['access_token_expires_at']).to be_present
       end
     end
 


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/189

## description
- JWT発行時に`exp` claimを追加し、有効期限を30日に設定
- ログインAPIのレスポンスに`access_token_expires_at`を追加
- 期限切れJWTで401を返すよう`JWT::ExpiredSignature`をrescueに追加
- request specを追加
