### PR TITLE
Heading.numberにバリデーションを追加

### DIFF
--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -4,5 +4,7 @@ class Heading < ApplicationRecord
   belongs_to :user_book
   has_one :memo, dependent: :destroy
 
+  validates :number, presence: true, numericality: { only_integer: true, greater_than: 0 }
+
   accepts_nested_attributes_for :memo
 end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Heading, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:book) { FactoryBot.create(:book) }
+  let(:user_book) { UserBook.create!(user:, book:) }
+
+  it 'is invalid without a number' do
+    heading = FactoryBot.build(:heading, user_book:, number: nil)
+
+    expect(heading).not_to be_valid
+  end
+
+  it 'is invalid when number is zero' do
+    heading = FactoryBot.build(:heading, user_book:, number: 0)
+
+    expect(heading).not_to be_valid
+  end
+
+  it 'is invalid when number is negative' do
+    heading = FactoryBot.build(:heading, user_book:, number: -1)
+
+    expect(heading).not_to be_valid
+  end
+
+  it 'is valid when number is a positive integer' do
+    heading = FactoryBot.build(:heading, user_book:, number: 1)
+
+    expect(heading).to be_valid
+  end
+end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/178

## description
- `Heading.number`に1以上の整数のみ許可するようにバリデーションを追加