### PR TITLE
UserBookの更新処理にtransactionを追加

### DIFF
--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -16,13 +16,23 @@ class UserBook < ApplicationRecord
   scope :status_finished_ordered, -> { status_finished.order(:position) }
 
   def swap_positions_with(item)
-    item_position = item.position
-
-    item.set_list_position(position)
-    set_list_position(item_position)
+    transaction do
+      item_position = item.position
+      item.set_list_position(position, true)
+      set_list_position(item_position, true)
+    end
+    true
+  rescue ActiveRecord::ActiveRecordError
+    false
   end
 
   def save_with_heading
-    save && headings.create!(number: 1, title: '', memo_attributes: {})
+    transaction do
+      save!
+      headings.create!(number: 1, title: '', memo_attributes: {})
+    end
+    true
+  rescue ActiveRecord::ActiveRecordError
+    false
   end
 end

--- a/spec/models/user_book_spec.rb
+++ b/spec/models/user_book_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe UserBook, type: :model do
       expect(second_user_book.position).to eq(1)
       expect(first_user_book.position).to eq(2)
     end
+
+    it 'rolls back when swapping the position fails halfway through' do
+      first_book = FactoryBot.create(:book)
+      second_book = FactoryBot.create(:book)
+      first_user_book = UserBook.create(user: current_user, book: first_book)
+      second_user_book = UserBook.create(user: current_user, book: second_book)
+
+      allow(first_user_book).to receive(:set_list_position).and_raise(ActiveRecord::ActiveRecordError)
+
+      expect(first_user_book.swap_positions_with(second_user_book)).to eq(false)
+      expect(first_user_book.reload.position).to eq(1)
+      expect(second_user_book.reload.position).to eq(2)
+    end
   end
 
   describe '#save_with_heading' do
@@ -35,6 +48,17 @@ RSpec.describe UserBook, type: :model do
     context 'when save is failed' do
       it 'returns false and book, user_book and headings are not saved' do
         allow(user_book).to receive(:save_with_heading).and_return(false)
+        expect(user_book.save_with_heading).to eq(false)
+        expect(UserBook.exists?(user: current_user, book:)).to eq(false)
+      end
+    end
+
+    context 'when heading creation fails' do
+      it 'returns false and does not leave the user_book behind' do
+        headings = instance_double(ActiveRecord::Associations::CollectionProxy)
+        allow(user_book).to receive(:headings).and_return(headings)
+        allow(headings).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(Heading.new))
+
         expect(user_book.save_with_heading).to eq(false)
         expect(UserBook.exists?(user: current_user, book:)).to eq(false)
       end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/176

## description
- `UserBook#save_with_heading`と`#swap_positions_with`をトランザクションで囲み、途中失敗時に中途半端な状態が残らないよう修正
- `set_list_position`には第2引数`true`を渡し、内部で`save!`を呼ばせて挙動を統一
- ロールバック動作を検証するmodel specを追加