### PR TITLE
Bookモデルの未使用スコープを削除

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -5,6 +5,4 @@ class Book < ApplicationRecord
 
   has_many :user_books, dependent: :destroy
   has_many :users, through: :user_books
-
-  scope :position_order, -> { order(position: :asc) }
 end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/179

## description
最初は`BooksController#index`で本一覧を表示していたが、`UserBooksController#index`で表示するように変更した際の削除漏れ。