### PR TITLE
pumaのバージョン指定を変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dotenv-rails'
 gem 'googleauth'
 gem 'jwt'
 gem 'pg'
-gem 'puma', '>= 5.0'
+gem 'puma', '>= 6.4', '< 7'
 gem 'rack-cors'
 gem 'rails', '8.0.2'
 gem 'tzinfo-data', platforms: %i[windows jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,7 @@ DEPENDENCIES
   googleauth
   jwt
   pg
-  puma (>= 5.0)
+  puma (>= 6.4, < 7)
   rack-cors
   rails (= 8.0.2)
   rspec-rails


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/170

## description
- 現行運用の実体はPuma 6.4.xなので、下限は`6.4`に寄せるのが自然。
- ただし`~> 6.4`ではなく`>= 6.4, < 7`を採用する。これにより6系の更新は許容しつつ、breaking changesを含みうる7系への自動流入を防ぐ。