### PR TITLE
本番環境のconfig.hostsを設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,10 +77,7 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = ['api.tsundoku.tech']
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == '/up' } }
 end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/195

## description
`config.hosts`および`config.host_authorization`のコメントアウトを外し、許可ホストの`api.tsundoku.tech`以外のHostヘッダーは403で拒否されるように設定。（Heroku標準URLは除外している。）