### PR TITLE
エラーレスポンス形式と作成系のステータスコードを統一

### DIFF
--- a/app/controllers/api/headings_controller.rb
+++ b/app/controllers/api/headings_controller.rb
@@ -6,9 +6,9 @@ module API
       user_book = current_user.user_books.find(params[:user_book_id])
       heading = Heading.new(user_book:, number: params[:number].to_i, title: '', memo_attributes: {})
       if heading.save
-        render json: HeadingResource.new(heading).serializable_hash
+        render json: HeadingResource.new(heading).serializable_hash, status: :created
       else
-        render json: { error: '章の追加に失敗しました。' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
 
@@ -17,7 +17,7 @@ module API
       if heading.update(title: params[:title])
         head :ok
       else
-        render json: { error: '章の更新に失敗しました' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
   end

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -12,7 +12,7 @@ module API
       if memo.update(body: params[:body])
         head :ok
       else
-        render json: { error: 'メモの登録に失敗しました' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
   end

--- a/app/controllers/api/reading_logs_controller.rb
+++ b/app/controllers/api/reading_logs_controller.rb
@@ -10,9 +10,9 @@ module API
       memo = current_user.memos.find(params[:memo_id])
       reading_log = ReadingLog.find_or_create_by(memo:, read_date: Time.zone.today)
       if reading_log.persisted?
-        head :ok
+        head :created
       else
-        render json: { error: 'ログの登録に失敗しました' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
   end

--- a/app/controllers/api/user_books_controller.rb
+++ b/app/controllers/api/user_books_controller.rb
@@ -16,13 +16,13 @@ module API
 
     def create
       book = Book.find_or_create_by(book_params)
-      return render json: { error: '本の登録に失敗しました。' }, status: :unprocessable_entity unless book.persisted?
+      return head :unprocessable_entity unless book.persisted?
 
       user_book = UserBook.new(book:, user: current_user)
       if user_book.save_with_heading
-        head :ok
+        head :created
       else
-        render json: { error: '本の登録に失敗しました。' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
 
@@ -31,7 +31,7 @@ module API
       if @user_book.swap_positions_with(destination_user_book)
         head :ok
       else
-        render json: [error: '本の並び替えに失敗しました。'], status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
 
@@ -39,7 +39,7 @@ module API
       if @user_book.update(status: params[:status])
         head :ok
       else
-        render json: { error: '本の情報の更新に失敗しました。' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
 
@@ -47,7 +47,7 @@ module API
       if @user_book.destroy
         head :no_content
       else
-        render json: { error: '本の削除に失敗しました。' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -25,7 +25,7 @@ module API
           access_token_expires_at: access_token_expires_at.iso8601
         }
       else
-        render json: { error: 'ログインに失敗しました' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
 
@@ -33,7 +33,7 @@ module API
       if current_user.destroy
         head :no_content
       else
-        render json: { error: '退会に失敗しました。' }, status: :unprocessable_entity
+        head :unprocessable_entity
       end
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::API
   end
 
   def render_unauthorized
-    render json: { errors: ['Not Authenticated'] }, status: :unauthorized
+    head :unauthorized
   end
 
   def verify_google_id_token
@@ -35,8 +35,8 @@ class ApplicationController < ActionController::API
 
     begin
       Google::Auth::IDTokens.verify_oidc(params[:id_token], aud: audience, iss: issuer)
-    rescue Google::Auth::IDTokens::VerificationError => e
-      render json: { errors: ["Not Authenticated #{e.message}"] }, status: :unauthorized
+    rescue Google::Auth::IDTokens::VerificationError
+      head :unauthorized
     end
   end
 end

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -12,14 +12,12 @@ RSpec.describe 'Authentication', type: :request do
       get api_reading_logs_path
 
       expect(response).to have_http_status(:unauthorized)
-      expect(response.parsed_body).to eq('errors' => ['Not Authenticated'])
     end
 
     it 'returns unauthorized when the token is invalid' do
       get api_reading_logs_path, headers: { Authorization: 'Bearer invalid.token' }
 
       expect(response).to have_http_status(:unauthorized)
-      expect(response.parsed_body).to eq('errors' => ['Not Authenticated'])
     end
 
     it 'returns unauthorized when the token user does not exist' do
@@ -28,7 +26,6 @@ RSpec.describe 'Authentication', type: :request do
       get api_reading_logs_path, headers: { Authorization: "Bearer #{token}" }
 
       expect(response).to have_http_status(:unauthorized)
-      expect(response.parsed_body).to eq('errors' => ['Not Authenticated'])
     end
 
     it 'returns unauthorized when the token is expired' do
@@ -37,7 +34,6 @@ RSpec.describe 'Authentication', type: :request do
       get api_reading_logs_path, headers: { Authorization: "Bearer #{token}" }
 
       expect(response).to have_http_status(:unauthorized)
-      expect(response.parsed_body).to eq('errors' => ['Not Authenticated'])
     end
 
     it 'returns ok when the token is valid' do

--- a/spec/requests/api/headings_spec.rb
+++ b/spec/requests/api/headings_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'API::Headings', type: :request do
       it 'succeeds adding heading' do
         params = { user_book_id: @user_book.id, number: 2 }
         expect { post(api_headings_path, params:) }.to change { Heading.count }.by(1)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:created)
       end
     end
 

--- a/spec/requests/api/reading_logs_spec.rb
+++ b/spec/requests/api/reading_logs_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'API::ReadingLogs', type: :request do
         new_memo = FactoryBot.create(:memo, heading: new_heading)
         params = { memo_id: new_memo.id }
         expect { post(api_reading_logs_path, params:) }.to change { ReadingLog.count }.by(1)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:created)
       end
     end
 

--- a/spec/requests/api/user_books_spec.rb
+++ b/spec/requests/api/user_books_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         expect { post(api_user_books_path, params:) }
           .to change { UserBook.count }.by(1)
           .and change { Book.count }.by(0)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:created)
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         expect { post(api_user_books_path, params:) }
           .to change { Book.count }.by(1)
           .and change { UserBook.count }.by(1)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:created)
       end
     end
 


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/175

## description
エラーレスポンスのキー名・形式が不統一かつfrontendでエラーボディを参照していないため、`head :status`に統一した。
副次的に、作成系の成功時ステータスを200→201に変更しREST規約に揃えた。
`POST /api/users`はログイン用途なので200のまま。
上記に合わせてrequest specも更新した。