### PR TITLE
複数のN+1問題を解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ group :development, :test do
 
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'pg_query'
+  gem 'prosopite'
   gem 'rspec-rails'
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,24 @@ GEM
       activesupport (>= 6.1)
     google-cloud-env (2.2.1)
       faraday (>= 1.0, < 3.a)
+    google-protobuf (4.33.6)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.6-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.6-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.6-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.6-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.6-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
     googleauth (1.11.2)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.1)
@@ -170,6 +188,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.8)
+    pg_query (6.2.2)
+      google-protobuf (>= 3.25.3)
+    prosopite (2.2.0)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
@@ -306,6 +327,8 @@ DEPENDENCIES
   googleauth
   jwt
   pg
+  pg_query
+  prosopite
   puma (>= 6.4, < 7)
   rack-cors
   rails (= 8.0.2)

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -3,7 +3,9 @@
 module API
   class MemosController < ApplicationController
     def index
-      user_book = UserBook.find_by!(user: current_user, book_id: params[:book_id])
+      user_book = UserBook
+                  .includes(:book, headings: :memo)
+                  .find_by!(user: current_user, book_id: params[:book_id])
       render json: UserBookWithMemosResource.new(user_book).serializable_hash
     end
 

--- a/app/controllers/api/user_books_controller.rb
+++ b/app/controllers/api/user_books_controller.rb
@@ -5,11 +5,12 @@ module API
     before_action :set_user_book, only: %i[update position destroy]
 
     def index
-      user_books = current_user.user_books
+      user_books = current_user.user_books.includes(:book).order(:position)
+      grouped = user_books.group_by(&:status)
       categorized_user_books = CategorizedUserBooks.new(
-        user_books.status_unread_ordered,
-        user_books.status_reading_ordered,
-        user_books.status_finished_ordered
+        grouped['unread'] || [],
+        grouped['reading'] || [],
+        grouped['finished'] || []
       )
       render json: UserBooksResource.new(categorized_user_books).serializable_hash
     end

--- a/app/resources/user_book_with_memos_resource.rb
+++ b/app/resources/user_book_with_memos_resource.rb
@@ -6,7 +6,7 @@ class UserBookWithMemosResource < BaseResource
 
   many :headings,
        proc { |headings|
-         headings.order(:id)
+         headings.sort_by(&:id)
        },
        resource: HeadingResource
 end

--- a/app/resources/user_info_resource.rb
+++ b/app/resources/user_info_resource.rb
@@ -4,10 +4,11 @@ class UserInfoResource < BaseResource
   attributes :name
 
   attribute :user_books do
+    grouped = object.user_books.includes(:book).group_by(&:status)
     categorized_user_books = CategorizedUserBooks.new(
-      object.user_books.status_unread,
-      object.user_books.status_reading,
-      object.user_books.status_finished
+      grouped['unread'] || [],
+      grouped['reading'] || [],
+      grouped['finished'] || []
     )
     UserBooksResource.new(categorized_user_books).serializable_hash
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,4 +52,10 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.after_initialize do
+    Prosopite.rails_logger = true
+    Prosopite.raise = true
+    Prosopite.ignore_queries = [/"position" IS NOT NULL/]
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include AuthorizationHelper
+
+  config.before(:each) { Prosopite.scan }
+  config.after(:each) { Prosopite.finish }
 end

--- a/spec/resources/user_books_resource_spec.rb
+++ b/spec/resources/user_books_resource_spec.rb
@@ -7,8 +7,13 @@ RSpec.describe UserBooksResource, type: :resource do
     user = FactoryBot.create(:user)
     books = FactoryBot.create_list(:book, 3)
     books.each_with_index { |book, i| UserBook.create(user:, book:, status: i) }
-    user_books = user.user_books
-    categorized_user_books = CategorizedUserBooks.new(user_books.status_unread, user_books.status_reading, user_books.status_finished)
+    user_books = user.user_books.includes(:book)
+    grouped = user_books.group_by(&:status)
+    categorized_user_books = CategorizedUserBooks.new(
+      grouped['unread'] || [],
+      grouped['reading'] || [],
+      grouped['finished'] || []
+    )
     user_books_json = UserBooksResource.new(categorized_user_books).serializable_hash.to_json
     expected_user_books_json = {
       unread_books: [


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/188

## description
N+1懸念4箇所を実コードと照合し、3箇所を修正、1箇所を据え置きとした。

### 修正内容
- `UserBooksController#index` : `includes(:book)`をchainし、status別に3本走っていたSELECTを `group_by(&:status)`で1本に統合。
- `MemosController#index` : `find_by!`の前に`includes(:book, headings: :memo)`をchainし、heading数分発火していたmemoのSELECTを解消。
- `UserInfoResource` : `object.user_books.includes(:book)` + `group_by(&:status)`に書き換え、controllerと同パターンに統一。
- `UserBookWithMemosResource` : `headings.order(:id)`を`sort_by(&:id)`に変更。ActiveRecordの`order`はpreload済みcollectionに対してSQLを再発行しpreloadを破壊するため、Rubyメモリ内ソートに切替えた。
- `spec/resources/user_books_resource_spec.rb` : controllerと同じ`group_by`パターンに修正。

### 据え置き
- `DailyReadingLogResource` : 「年ごとに別クエリ」は誤認識のため対応外。実コードは `reading_logs.group(:read_date).count`の単一`GROUP BY + COUNT`クエリで、年単位分割はRubyの`Enumerable#group_by`。SQLは再発行していない。

### 回帰防止 (Prosopite 導入)
テスト実行時にN+1が混入したら例外で落ちる構成にした。
- `Gemfile` : `prosopite`,`pg_query`をdevelopment/testに追加
- `config/environments/test.rb` : `Prosopite.raise = true`設定
- `spec/rails_helper.rb` : `before(:each) { Prosopite.scan }` / `after(:each) { Prosopite.finish }`を仕込み、全テストに自動適用
