### PR TITLE
Googleログインのユーザー識別を検証済みID tokenのclaimに基づくように変更

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -13,9 +13,10 @@ module API
     end
 
     def create
-      user = User.find_or_create_by(user_params)
+      user = User.find_or_initialize_by(email: @google_claims['email'])
+      user.assign_attributes(name: @google_claims['name'], avatar_url: @google_claims['picture'])
 
-      if user.persisted?
+      if user.save
         access_token_expires_at = JWT_EXPIRATION.from_now
         encoded_token = encode_jwt({ id: user.id, exp: access_token_expires_at.to_i })
 
@@ -38,10 +39,6 @@ module API
     end
 
     private
-
-    def user_params
-      params.permit(:name, :email, :avatar_url)
-    end
 
     def encode_jwt(payload)
       secret_key = ENV.fetch('SECRET_KEY_BASE')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::API
     issuer = ENV.fetch('ISSUER')
 
     begin
-      Google::Auth::IDTokens.verify_oidc(params[:id_token], aud: audience, iss: issuer)
+      @google_claims = Google::Auth::IDTokens.verify_oidc(params[:id_token], aud: audience, iss: issuer)
     rescue Google::Auth::IDTokens::VerificationError
       head :unauthorized
     end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'API::Users', type: :request do
   describe 'API::UsersController#create' do
     context 'registering new user' do
       it 'returns a ok response' do
-        user_params = { name: 'hoge', email: Faker::Internet.email, avatar_url: Faker::Internet.url }
-        expect { post api_auth_callback_google_path, params: user_params }.to change { User.count }.by(1)
+        google_id_token_stub('email' => Faker::Internet.email, 'name' => 'hoge', 'picture' => Faker::Internet.url)
+        expect { post api_auth_callback_google_path, params: { id_token: 'id_token' } }.to change { User.count }.by(1)
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body['access_token']).to be_present
         expect(response.parsed_body['access_token_expires_at']).to be_present
@@ -27,18 +27,37 @@ RSpec.describe 'API::Users', type: :request do
 
     context 'when a user logs in' do
       it 'returns a ok response' do
-        user_params = { name: current_user.name, email: current_user.email, avatar_url: current_user.avatar_url }
-        post api_auth_callback_google_path, params: user_params
+        expect { post api_auth_callback_google_path, params: { id_token: 'id_token' } }.not_to(change { User.count })
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body['access_token']).to be_present
         expect(response.parsed_body['access_token_expires_at']).to be_present
       end
     end
 
-    context 'params is invalid' do
+    context 'when an existing user logs in with a changed name and avatar' do
+      it 'updates the profile without creating a new user' do
+        google_id_token_stub('email' => current_user.email, 'name' => 'new name', 'picture' => 'https://example.com/new-avatar.png')
+        expect { post api_auth_callback_google_path, params: { id_token: 'id_token' } }.not_to(change { User.count })
+        expect(response).to have_http_status(:ok)
+        expect(current_user.reload.name).to eq 'new name'
+        expect(current_user.avatar_url).to eq 'https://example.com/new-avatar.png'
+      end
+    end
+
+    context 'when the request body email differs from the token email' do
+      it 'identifies the user by the token email' do
+        user_params = { name: 'attacker', email: 'attacker@example.com', avatar_url: Faker::Internet.url, id_token: 'id_token' }
+        expect { post api_auth_callback_google_path, params: user_params }.not_to(change { User.count })
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['id']).to eq current_user.id
+        expect(User.exists?(email: 'attacker@example.com')).to be false
+      end
+    end
+
+    context 'when token claims lack an email' do
       it 'returns a bad response' do
-        user_params = { name: 'hoge', avatar_url: Faker::Internet.url }
-        post api_auth_callback_google_path, params: user_params
+        google_id_token_stub('email' => nil, 'name' => 'hoge', 'picture' => Faker::Internet.url)
+        post api_auth_callback_google_path, params: { id_token: 'id_token' }
         expect(response).to have_http_status(422)
       end
     end

--- a/spec/support/authorization_helper.rb
+++ b/spec/support/authorization_helper.rb
@@ -4,6 +4,12 @@ module AuthorizationHelper
   def authorization_stub
     allow_any_instance_of(ApplicationController).to receive(:authenticate).and_return(current_user)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
-    allow_any_instance_of(ApplicationController).to receive(:verify_google_id_token).and_return(true)
+    google_id_token_stub('email' => current_user.email, 'name' => current_user.name, 'picture' => current_user.avatar_url)
+  end
+
+  def google_id_token_stub(claims)
+    allow_any_instance_of(ApplicationController).to receive(:verify_google_id_token) do |controller|
+      controller.instance_variable_set(:@google_claims, claims)
+    end
   end
 end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/234

## description
Googleログインのユーザー識別を、リクエストボディではなく検証済みID tokenのclaimに基づけるようにした。

- `verify_google_id_token`の検証結果を`@google_claims`に保持
- `create`を「クレームの`email`で`find_or_initialize_by` → `name/avatar`をclaimの値で更新 → `save`」に変更し、不要になった`user_params`を削除
- テスト追加 : 名前/アイコン変更後の再ログイン（200・重複なし・プロフィール更新）、bodyとトークンのemailが異なる場合はトークン側を採用

これにより、Googleの表示名・アイコン変更後もログインでき、プロフィールはログインのたびに最新化される。

⚠️ Frontend側のPRより先に本PRをマージ・デプロイすること（本変更は旧Frontendと互換があるため、こちらが先なら安全）。