### PR TITLE
テストカバレッジの計測設定を是正し未カバー箇所のテストを追加

### DIFF
--- a/app/resources/daily_reading_log_resource.rb
+++ b/app/resources/daily_reading_log_resource.rb
@@ -9,6 +9,7 @@ class DailyReadingLogResource < BaseResource
     else
       daily_counts = reading_logs
                      .group(:read_date)
+                     .order(:read_date)
                      .count
                      .transform_keys(&:to_date)
       logs_by_year = daily_counts.group_by { |date, _| date.year }

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -44,4 +44,37 @@ RSpec.describe 'Authentication', type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'POST /api/auth/callback/google' do
+    let(:audience) { 'test-audience' }
+    let(:issuer) { 'https://accounts.google.com' }
+    let(:claims) { { 'email' => user.email, 'name' => user.name, 'picture' => user.avatar_url } }
+
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('AUDIENCE').and_return(audience)
+      allow(ENV).to receive(:fetch).with('ISSUER').and_return(issuer)
+    end
+
+    it 'returns ok when the Google ID token is verified' do
+      allow(Google::Auth::IDTokens).to receive(:verify_oidc)
+        .with('valid_token', aud: audience, iss: issuer)
+        .and_return(claims)
+
+      post api_auth_callback_google_path, params: { id_token: 'valid_token' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['access_token']).to be_present
+    end
+
+    it 'returns unauthorized when the Google ID token verification fails' do
+      allow(Google::Auth::IDTokens).to receive(:verify_oidc)
+        .and_raise(Google::Auth::IDTokens::VerificationError)
+
+      expect { post api_auth_callback_google_path, params: { id_token: 'tampered_token' } }
+        .not_to(change { User.count })
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end

--- a/spec/requests/api/headings_spec.rb
+++ b/spec/requests/api/headings_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe 'API::Headings', type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'when number is invalid' do
+      it 'returns a bad response' do
+        params = { user_book_id: @user_book.id, number: 0 }
+        expect { post(api_headings_path, params:) }.not_to(change { Heading.count })
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 
   describe 'API::HeadingsController#update' do
@@ -57,7 +65,7 @@ RSpec.describe 'API::Headings', type: :request do
         allow_any_instance_of(Heading).to receive(:update).and_return(false)
         params = { id: @heading.id, title: '更新後のタイトル' }
         patch(api_heading_path(@heading.id), params:)
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 

--- a/spec/requests/api/memos_spec.rb
+++ b/spec/requests/api/memos_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'API::Memos', type: :request do
         allow_any_instance_of(Memo).to receive(:update).and_return(false)
         params = { id: @memo.id, body: '更新後のメモ' }
         patch(api_memo_path(@memo.id), params:)
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 

--- a/spec/requests/api/reading_logs_spec.rb
+++ b/spec/requests/api/reading_logs_spec.rb
@@ -54,5 +54,18 @@ RSpec.describe 'API::ReadingLogs', type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'when saving the reading log fails' do
+      it 'returns a bad response' do
+        new_heading = FactoryBot.create(:heading, user_book: @user_book)
+        new_memo = FactoryBot.create(:memo, heading: new_heading)
+        allow(ReadingLog).to receive(:find_or_create_by).and_return(ReadingLog.new)
+
+        params = { memo_id: new_memo.id }
+        post(api_reading_logs_path, params:)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 end

--- a/spec/requests/api/user_books_spec.rb
+++ b/spec/requests/api/user_books_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         expect { post(api_user_books_path, params:) }
           .to change { Book.count }.by(0)
           .and change { UserBook.count }.by(0)
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         allow_any_instance_of(UserBook).to receive(:save_with_heading).and_return(false)
         params = { title: @book.title, author: @book.author, coverImageUrl: @book.cover_image_url }
         post(api_user_books_path, params:)
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
@@ -83,7 +83,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         allow_any_instance_of(UserBook).to receive(:swap_positions_with).and_return(false)
         params = { user_book_id: @user_book.id, destination_book_id: second_user_book.id }
         patch(position_api_user_book_path(@user_book.id), params:)
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
@@ -115,7 +115,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         allow_any_instance_of(UserBook).to receive(:update).and_return(false)
         params = { user_book_id: @user_book.id, status: 'reading' }
         patch(api_user_book_path(@user_book.id), params:)
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         allow_any_instance_of(UserBook).to receive(:destroy).and_return(false)
         params = { user_book_id: @user_book.id }
         expect { delete(api_user_book_path(@user_book.id), params:) }.not_to(change { UserBook.count })
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'API::Users', type: :request do
       it 'returns a bad response' do
         google_id_token_stub('email' => nil, 'name' => 'hoge', 'picture' => Faker::Internet.url)
         post api_auth_callback_google_path, params: { id_token: 'id_token' }
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
@@ -85,7 +85,7 @@ RSpec.describe 'API::Users', type: :request do
       it 'return a bad response' do
         allow(current_user).to receive(:destroy).and_return(false)
         delete("/api/users/#{current_user.id}")
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start 'rails' do
+  enable_coverage :branch
+end
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'simplecov'
 SimpleCov.start 'rails' do
   enable_coverage :branch
+  minimum_coverage line: 95, branch: 90 if ENV['CI']
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/236

## description
テストカバレッジ再確認の過程で、判明した問題点を修正

- SimpleCovを`rails`プロファイル + branchカバレッジ計測に変更し、spec/config等を集計対象から除外（従来の98.91%はテストコード等を含んだ水増し値で、app配下の実測は97.06%だった）
- 未カバーだった3箇所にテストを追加
  - `ApplicationController#verify_google_id_token`の検証成功/失敗（401）：従来はメソッドごとstubしており検証本体が一度も実行されていなかったため、stubを外部ライブラリ呼び出し（`verify_oidc`）に絞って実体を通すように変更
  - `API::HeadingsController#create`の保存失敗
  - `API::ReadingLogsController#create`の保存失敗
- `minimum_coverage line: 95, branch: 90`を設定し、CIのrspec実行でカバレッジ低下を検知できるようにした
- 副次的に、`DailyReadingLogResource`の集計クエリに`ORDER BY`が無く年キーの並び順が不定でspecがflakyだった問題を`.order(:read_date)`で修正（Frontend側は年キーをJS仕様で昇順正規化して扱っており影響なしを確認済み）
