### PR TITLE
net-imapを更新して脆弱性に対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/238

## description
CI `security`の失敗を解消。
原因は、`net-imap 0.6.4`の脆弱性勧告で、コード変更とは無関係。
0.6.4.1に更新。