### PR TITLE
非推奨の:unprocessable_entityを:unprocessable_contentへ置換

### DIFF
--- a/app/controllers/api/headings_controller.rb
+++ b/app/controllers/api/headings_controller.rb
@@ -8,7 +8,7 @@ module API
       if heading.save
         render json: HeadingResource.new(heading).serializable_hash, status: :created
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
 
@@ -17,7 +17,7 @@ module API
       if heading.update(title: params[:title])
         head :ok
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
   end

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -14,7 +14,7 @@ module API
       if memo.update(body: params[:body])
         head :ok
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
   end

--- a/app/controllers/api/reading_logs_controller.rb
+++ b/app/controllers/api/reading_logs_controller.rb
@@ -12,7 +12,7 @@ module API
       if reading_log.persisted?
         head :created
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
   end

--- a/app/controllers/api/user_books_controller.rb
+++ b/app/controllers/api/user_books_controller.rb
@@ -17,13 +17,13 @@ module API
 
     def create
       book = Book.find_or_create_by(book_params)
-      return head :unprocessable_entity unless book.persisted?
+      return head :unprocessable_content unless book.persisted?
 
       user_book = UserBook.new(book:, user: current_user)
       if user_book.save_with_heading
         head :created
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
 
@@ -32,7 +32,7 @@ module API
       if @user_book.swap_positions_with(destination_user_book)
         head :ok
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
 
@@ -40,7 +40,7 @@ module API
       if @user_book.update(status: params[:status])
         head :ok
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
 
@@ -48,7 +48,7 @@ module API
       if @user_book.destroy
         head :no_content
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -26,7 +26,7 @@ module API
           access_token_expires_at: access_token_expires_at.iso8601
         }
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
 
@@ -34,7 +34,7 @@ module API
       if current_user.destroy
         head :no_content
       else
-        head :unprocessable_entity
+        head :unprocessable_content
       end
     end
 

--- a/spec/requests/api/headings_spec.rb
+++ b/spec/requests/api/headings_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'API::Headings', type: :request do
       it 'returns a bad response' do
         params = { user_book_id: @user_book.id, number: 0 }
         expect { post(api_headings_path, params:) }.not_to(change { Heading.count })
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe 'API::Headings', type: :request do
         allow_any_instance_of(Heading).to receive(:update).and_return(false)
         params = { id: @heading.id, title: '更新後のタイトル' }
         patch(api_heading_path(@heading.id), params:)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/api/memos_spec.rb
+++ b/spec/requests/api/memos_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'API::Memos', type: :request do
         allow_any_instance_of(Memo).to receive(:update).and_return(false)
         params = { id: @memo.id, body: '更新後のメモ' }
         patch(api_memo_path(@memo.id), params:)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/api/reading_logs_spec.rb
+++ b/spec/requests/api/reading_logs_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'API::ReadingLogs', type: :request do
         params = { memo_id: new_memo.id }
         post(api_reading_logs_path, params:)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/api/user_books_spec.rb
+++ b/spec/requests/api/user_books_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         expect { post(api_user_books_path, params:) }
           .to change { Book.count }.by(0)
           .and change { UserBook.count }.by(0)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         allow_any_instance_of(UserBook).to receive(:save_with_heading).and_return(false)
         params = { title: @book.title, author: @book.author, coverImageUrl: @book.cover_image_url }
         post(api_user_books_path, params:)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -83,7 +83,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         allow_any_instance_of(UserBook).to receive(:swap_positions_with).and_return(false)
         params = { user_book_id: @user_book.id, destination_book_id: second_user_book.id }
         patch(position_api_user_book_path(@user_book.id), params:)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -115,7 +115,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         allow_any_instance_of(UserBook).to receive(:update).and_return(false)
         params = { user_book_id: @user_book.id, status: 'reading' }
         patch(api_user_book_path(@user_book.id), params:)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         allow_any_instance_of(UserBook).to receive(:destroy).and_return(false)
         params = { user_book_id: @user_book.id }
         expect { delete(api_user_book_path(@user_book.id), params:) }.not_to(change { UserBook.count })
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'API::Users', type: :request do
       it 'returns a bad response' do
         google_id_token_stub('email' => nil, 'name' => 'hoge', 'picture' => Faker::Internet.url)
         post api_auth_callback_google_path, params: { id_token: 'id_token' }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -85,7 +85,7 @@ RSpec.describe 'API::Users', type: :request do
       it 'return a bad response' do
         allow(current_user).to receive(:destroy).and_return(false)
         delete("/api/users/#{current_user.id}")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/240

## description
非推奨シンボルを置換。ステータスコードは不変。