### PR TITLE
headingsの並び順をassociationへ移してresourceのprocを削除

### DIFF
--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -35,4 +35,8 @@ class UserBook < ApplicationRecord
   rescue ActiveRecord::ActiveRecordError
     false
   end
+
+  def ordered_headings
+    headings.sort_by(&:id)
+  end
 end

--- a/app/resources/user_book_with_memos_resource.rb
+++ b/app/resources/user_book_with_memos_resource.rb
@@ -4,9 +4,5 @@ class UserBookWithMemosResource < BaseResource
   attributes :id, :status
   one :book, resource: BookResource
 
-  many :headings,
-       proc { |headings|
-         headings.sort_by(&:id)
-       },
-       resource: HeadingResource
+  many :ordered_headings, key: :headings, resource: HeadingResource
 end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/157

## description
`UserBookWithMemosResource`のproc（headingsをid順にソート）を削除し、並び替えを`UserBook#ordered_headings`に切り出して`many :ordered_headings, key: :headings`で参照。出力JSONは不変。