### PR TITLE
UserBookの未使用スコープstatus_*_orderedを削除

### DIFF
--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -11,10 +11,6 @@ class UserBook < ApplicationRecord
 
   acts_as_list scope: :user
 
-  scope :status_unread_ordered, -> { status_unread.order(:position) }
-  scope :status_reading_ordered, -> { status_reading.order(:position) }
-  scope :status_finished_ordered, -> { status_finished.order(:position) }
-
   def swap_positions_with(item)
     transaction do
       item_position = item.position


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/241

## description
Issueに記載。