### PR TITLE
APIエラー応答に原因を含む{ error }ボディを返却

### DIFF
--- a/app/controllers/api/headings_controller.rb
+++ b/app/controllers/api/headings_controller.rb
@@ -8,7 +8,7 @@ module API
       if heading.save
         render json: HeadingResource.new(heading).serializable_hash, status: :created
       else
-        head :unprocessable_content
+        render_unprocessable(heading)
       end
     end
 
@@ -17,7 +17,7 @@ module API
       if heading.update(title: params[:title])
         head :ok
       else
-        head :unprocessable_content
+        render_unprocessable(heading)
       end
     end
   end

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -14,7 +14,7 @@ module API
       if memo.update(body: params[:body])
         head :ok
       else
-        head :unprocessable_content
+        render_unprocessable(memo)
       end
     end
   end

--- a/app/controllers/api/reading_logs_controller.rb
+++ b/app/controllers/api/reading_logs_controller.rb
@@ -12,7 +12,7 @@ module API
       if reading_log.persisted?
         head :created
       else
-        head :unprocessable_content
+        render_unprocessable(reading_log)
       end
     end
   end

--- a/app/controllers/api/user_books_controller.rb
+++ b/app/controllers/api/user_books_controller.rb
@@ -17,13 +17,13 @@ module API
 
     def create
       book = Book.find_or_create_by(book_params)
-      return head :unprocessable_content unless book.persisted?
+      return render_unprocessable(book) unless book.persisted?
 
       user_book = UserBook.new(book:, user: current_user)
       if user_book.save_with_heading
         head :created
       else
-        head :unprocessable_content
+        render_unprocessable(user_book)
       end
     end
 
@@ -32,7 +32,7 @@ module API
       if @user_book.swap_positions_with(destination_user_book)
         head :ok
       else
-        head :unprocessable_content
+        render_unprocessable
       end
     end
 
@@ -40,7 +40,7 @@ module API
       if @user_book.update(status: params[:status])
         head :ok
       else
-        head :unprocessable_content
+        render_unprocessable(@user_book)
       end
     end
 
@@ -48,7 +48,7 @@ module API
       if @user_book.destroy
         head :no_content
       else
-        head :unprocessable_content
+        render_unprocessable(@user_book)
       end
     end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -26,7 +26,7 @@ module API
           access_token_expires_at: access_token_expires_at.iso8601
         }
       else
-        head :unprocessable_content
+        render_unprocessable(user)
       end
     end
 
@@ -34,7 +34,7 @@ module API
       if current_user.destroy
         head :no_content
       else
-        head :unprocessable_content
+        render_unprocessable(current_user)
       end
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,12 @@ class ApplicationController < ActionController::API
     head :unauthorized
   end
 
+  def render_unprocessable(record = nil)
+    messages = record&.errors&.full_messages
+    messages = ['Unprocessable entity'] if messages.blank?
+    render json: { error: messages }, status: :unprocessable_content
+  end
+
   def verify_google_id_token
     audience = ENV.fetch('AUDIENCE')
     issuer = ENV.fetch('ISSUER')

--- a/spec/requests/api/headings_spec.rb
+++ b/spec/requests/api/headings_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'API::Headings', type: :request do
         params = { user_book_id: @user_book.id, number: 0 }
         expect { post(api_headings_path, params:) }.not_to(change { Heading.count })
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
   end
@@ -66,6 +67,7 @@ RSpec.describe 'API::Headings', type: :request do
         params = { id: @heading.id, title: '更新後のタイトル' }
         patch(api_heading_path(@heading.id), params:)
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
 

--- a/spec/requests/api/memos_spec.rb
+++ b/spec/requests/api/memos_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'API::Memos', type: :request do
         params = { id: @memo.id, body: '更新後のメモ' }
         patch(api_memo_path(@memo.id), params:)
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
 

--- a/spec/requests/api/reading_logs_spec.rb
+++ b/spec/requests/api/reading_logs_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe 'API::ReadingLogs', type: :request do
         post(api_reading_logs_path, params:)
 
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
   end

--- a/spec/requests/api/user_books_spec.rb
+++ b/spec/requests/api/user_books_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe 'API::UserBooks', type: :request do
           .to change { Book.count }.by(0)
           .and change { UserBook.count }.by(0)
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
 
@@ -61,6 +62,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         params = { title: @book.title, author: @book.author, coverImageUrl: @book.cover_image_url }
         post(api_user_books_path, params:)
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
   end
@@ -84,6 +86,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         params = { user_book_id: @user_book.id, destination_book_id: second_user_book.id }
         patch(position_api_user_book_path(@user_book.id), params:)
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
 
@@ -116,6 +119,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         params = { user_book_id: @user_book.id, status: 'reading' }
         patch(api_user_book_path(@user_book.id), params:)
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
 
@@ -147,6 +151,7 @@ RSpec.describe 'API::UserBooks', type: :request do
         params = { user_book_id: @user_book.id }
         expect { delete(api_user_book_path(@user_book.id), params:) }.not_to(change { UserBook.count })
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe 'API::Users', type: :request do
         google_id_token_stub('email' => nil, 'name' => 'hoge', 'picture' => Faker::Internet.url)
         post api_auth_callback_google_path, params: { id_token: 'id_token' }
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
   end
@@ -91,6 +92,7 @@ RSpec.describe 'API::Users', type: :request do
         allow(current_user).to receive(:destroy).and_return(false)
         delete("/api/users/#{current_user.id}")
         expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['error']).to be_present
       end
     end
   end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/246

## description
失敗時に`head :unprocessable_content`のみを返していたのを、原因を`{ error: [...] }`ボディ付きで返すよう変更。statusだけでは区別できなかった422の原因を、フロントで切り分け可能にする。

- `ApplicationController#render_unprocessable`を追加し、5コントローラの`head :unprocessable_content`を置換。
- statusは422のまま。
- 各request specの422ケースに`{ error }`の存在検証を追加。