### PR TITLE
acts_as_listのscopeにstatusを追加しステータスごとにpositionを管理

### DIFF
--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -9,7 +9,7 @@ class UserBook < ApplicationRecord
 
   enum :status, { unread: 0, reading: 1, finished: 2 }, prefix: true
 
-  acts_as_list scope: :user
+  acts_as_list scope: %i[user_id status]
 
   def swap_positions_with(item)
     transaction do

--- a/db/migrate/20260628113436_renumber_user_book_positions_by_status.rb
+++ b/db/migrate/20260628113436_renumber_user_book_positions_by_status.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# acts_as_listのscopeをuser_id単位から(user_id, status)単位へ変更したことに伴い、
+# 既存のuser_books.positionをステータスごとに1始まりの連番へ振り直すデータマイグレーション。
+class RenumberUserBookPositionsByStatus < ActiveRecord::Migration[8.0]
+  def up
+    execute(<<~SQL.squish)
+      UPDATE user_books AS ub
+      SET position = sub.new_position
+      FROM (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY user_id, status
+                 ORDER BY position ASC NULLS LAST, id ASC
+               ) AS new_position
+        FROM user_books
+      ) AS sub
+      WHERE ub.id = sub.id
+        AND ub.position IS DISTINCT FROM sub.new_position;
+    SQL
+  end
+
+  def down
+    # 元のグローバル連番は復元できないため、ロールバックは非対応とする。
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_28_065943) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_28_113436) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "books", force: :cascade do |t|
     t.string "title", null: false


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/248

## description
- `acts_as_list scope: %i[user_id status]に変更。status変更時にacts_as_listが「旧リストの詰め + 新リスト末尾への配置」を自動で行うため、コントローラ側の変更は不要。
- 既存データのpositionをステータスごとの1始まり連番に振り直すデータマイグレーションを追加（従来の表示順は維持）