### PR TITLE
依存gem(crass)の脆弱性に対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       thor (~> 1.0)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     debug (1.9.2)
       irb (~> 1.10)


### PR DESCRIPTION
## Issue
- なし（PR #79 の作業中に発見）

## description
`bundle update crass --conservative`で1.0.6→1.0.7へ更新