### PR TITLE
一覧系request specのデータを複数件にしてN+1を検知可能にする

### DIFF
--- a/spec/requests/api/memos_spec.rb
+++ b/spec/requests/api/memos_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'API::Memos', type: :request do
 
   before do
     @book = FactoryBot.create(:book)
-    user_book = UserBook.create(user: current_user, book: @book)
-    heading = FactoryBot.create(:heading, user_book:)
+    @user_book = UserBook.create(user: current_user, book: @book)
+    heading = FactoryBot.create(:heading, user_book: @user_book)
     @memo = FactoryBot.create(:memo, heading:)
     authorization_stub
   end
@@ -17,6 +17,8 @@ RSpec.describe 'API::Memos', type: :request do
   describe 'API::MemosController#index' do
     context 'params is valid' do
       it 'returns a successful response' do
+        second_heading = FactoryBot.create(:heading, user_book: @user_book)
+        FactoryBot.create(:memo, heading: second_heading)
         params = { book_id: @book.id }
         get(api_memos_path, params:)
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/user_books_spec.rb
+++ b/spec/requests/api/user_books_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'API::UserBooks', type: :request do
   describe 'API::BooksController#index' do
     context 'params is valid' do
       it 'returns a successful response' do
+        second_user_book
         get(api_user_books_path)
         expect(response).to have_http_status(:ok)
       end


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/254

## description
テストデータが1件だと、ProsopiteはN+1を検知できない。（クエリの繰り返しが発生しないため）
一覧形request specでデータを2件以上にし、テストで検出できるようにした。（実際、`includes`を消しても通過してしまうことを確認済み）