### PR TITLE
websocket-driverを0.8.2に更新（脆弱性対応）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## description
PR #82 作業中に検知。以下4件の勧告から、最も厳しい0.8.2に合わせる。

| CVE / GHSA | 内容 | 要求バージョン |
| --- | --- | --- |
| CVE-2026-54463 | プロトコル長ヘッダ悪用によるメモリ枯渇 | >= 0.8.1 |
| CVE-2026-54464 | メッセージ圧縮を悪用したリソース制限バイパス | >= 0.8.1 |
| CVE-2026-54465 | HTTPヘッダパーサでのメモリ枯渇 | >= 0.8.1 |
| GHSA-2x63-gw47-w4mm | 不正なHostヘッダによるDoS | >= 0.8.2 |
